### PR TITLE
fix: 명함첩 전체목록 조회 시, '주식회사' 또는 '(주)'글자 미포함되게 return값 주도록 변경

### DIFF
--- a/src/main/java/com/sparta/finalpj/service/CardService.java
+++ b/src/main/java/com/sparta/finalpj/service/CardService.java
@@ -158,15 +158,28 @@ public class CardService {
             return ResponseDto.success("명함을 등록해주세요");
         }
 
+
+
         for (Card card : cardList) {
+            String companyStr = card.getCompany();
+            String company = "";
+            if(companyStr.contains("주식회사")) {
+                company = companyStr.replace("주식회사", " ").trim();
+
+            } else if (companyStr.contains("(주)")) {
+                company = companyStr.replace("(주)", " ").trim();
+            } else {
+                company = companyStr;
+            }
+
             cardResponseDtoList.add(
                     CardResponseDto.builder()
                             .id(card.getId())
                             .cardName(card.getCardName())
                             .email(card.getEmail())
                             .phoneNum(card.getPhoneNum())
-                            .company(card.getCompany())
-                            .department(card.getCompany())
+                            .company(company)
+                            .department(card.getDepartment())
                             .position(card.getPosition())
                             .companyAddress(card.getCompanyAddress())
                             .tel(card.getTel())


### PR DESCRIPTION
## 어떤 것에 대한 PR인가요? :mag:
- 명함첩 전체목록 조회 시, '주식회사' 또는 '(주)'글자 미포함되게 return값 주도록 변경

## 변경사항 :memo:
- CardService 변경

## 코멘트 :page_with_curl:
